### PR TITLE
Add new API to retrieve medical-needs

### DIFF
--- a/types.bal
+++ b/types.bal
@@ -27,14 +27,13 @@ type MedicalItem record {
 };
 
 type MedicalNeed record {
-    int needID = -1;
-    int itemID;
-    int beneficiaryID;
+    int needID;
+    MedicalItem item;
     time:Date period;
     string urgency;
     int neededQuantity;
     int remainingQuantity;
-    Beneficiary? beneficiary = ();
+    Beneficiary beneficiary;
 };
 
 type Quotation record {


### PR DESCRIPTION
## Purpose
> $subject

Part of [#485](https://github.com/LSFLK/MedicinesforLK/issues/485)

## Examples
Following will be a sample response from the API:
```sh
[
  {
    "needID": 3,
    "item": {
      "itemID": 3,
      "name": "ACETYLCYSTEINE SOLUTION USP 200MG",
      "type": "Medicine",
      "unit": "vial"
    },
    "period": {
      "year": 2022,
      "month": 12,
      "day": 1
    },
    "urgency": "Urgent",
    "neededQuantity": 30000,
    "remainingQuantity": 30000,
    "beneficiary": {
      "beneficiaryID": 1,
      "name": "MoH / MSD",
      "shortName": "MoH / MSD",
      "email": "E-N/A",
      "phoneNumber": "P-N/A"
    }
  }
]
```